### PR TITLE
ci(badge): capitalize badge labels and fix coverage update regex

### DIFF
--- a/.github/workflows/badge.yaml
+++ b/.github/workflows/badge.yaml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   badge:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
@@ -56,7 +60,7 @@ jobs:
           else COLOR="red"
           fi
           URL_PCT=$(printf '%s' "$PCT" | sed 's/\./%2E/g')
-          sed -i "s|img\.shields\.io/badge/coverage-[^\"]*|img.shields.io/badge/coverage-${URL_PCT}%25-${COLOR}|" README.md
+          sed -i "s|img\.shields\.io/badge/Coverage-[^\"]*|img.shields.io/badge/Coverage-${URL_PCT}%25-${COLOR}|" README.md
         shell: bash
 
       - name: Commit badge

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 <p align="center">
   <a href="https://github.com/jedi-knights/yoda.nvim/actions/workflows/ci.yml"><img src="https://github.com/jedi-knights/yoda.nvim/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/jedi-knights/yoda.nvim/actions/workflows/badge.yaml"><img src="https://github.com/jedi-knights/yoda.nvim/actions/workflows/badge.yaml/badge.svg" alt="Badge"></a>
-  <img src="https://img.shields.io/badge/tests-191%20passing-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/Tests-191%20passing-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/quality-15%2F15%20★-gold" alt="Code Quality">
-  <a href="https://jedi-knights.github.io/yoda.nvim/"><img src="https://img.shields.io/badge/coverage-100%2E0%25-brightgreen" alt="Coverage"></a>
+  <a href="https://jedi-knights.github.io/yoda.nvim/"><img src="https://img.shields.io/badge/Coverage-100%2E0%25-brightgreen" alt="Coverage"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Capitalize `tests` → `Tests` and `coverage` → `Coverage` in README shield badge labels
- Fix `badge.yaml` sed regex to match the renamed `Coverage` label so CI auto-updates work
- Add `concurrency: group: pages` to prevent duplicate `github-pages` artifact errors

## Motivation
Badge labels were inconsistently cased. The rename also broke the sed pattern in the Badge workflow that updates the coverage percentage after each CI run, causing silent no-ops. The concurrency group prevents a recurring failure where rapid back-to-back CI completions triggered simultaneous Badge runs that each uploaded a `github-pages` artifact, causing `deploy-pages` to abort with "Multiple artifacts found".

## Changes
- `README.md`: capitalize `Tests` and `Coverage` shield badge labels
- `.github/workflows/badge.yaml`: update sed pattern from `coverage` to `Coverage`; add `concurrency` block with `group: pages` and `cancel-in-progress: false`

## Test Plan
- [ ] Merge and confirm Badge workflow completes without the duplicate artifact error
- [ ] Confirm coverage percentage in README badge updates correctly after the next CI run