### PR TITLE
docs(readme): remove unexplained quality badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
   <a href="https://github.com/jedi-knights/yoda.nvim/actions/workflows/ci.yml"><img src="https://github.com/jedi-knights/yoda.nvim/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/jedi-knights/yoda.nvim/actions/workflows/badge.yaml"><img src="https://github.com/jedi-knights/yoda.nvim/actions/workflows/badge.yaml/badge.svg" alt="Badge"></a>
   <img src="https://img.shields.io/badge/Tests-191%20passing-brightgreen" alt="Tests">
-  <img src="https://img.shields.io/badge/quality-15%2F15%20★-gold" alt="Code Quality">
   <a href="https://jedi-knights.github.io/yoda.nvim/"><img src="https://img.shields.io/badge/Coverage-100%2E0%25-brightgreen" alt="Coverage"></a>
 </p>
 

--- a/neospec.toml
+++ b/neospec.toml
@@ -3,4 +3,4 @@ test_patterns  = ["tests/unit/**/*_spec.lua"]
 coverage_dir   = "coverage"
 formats        = ["console", "lcov"]
 init_file        = "tests/minimal_init_fast.lua"
-coverage_include = ["lua/"]
+coverage_include = ["lua/yoda/"]


### PR DESCRIPTION
## Summary
- Removes the hardcoded `quality - 15/15 ★` badge from the README badge row
- Also includes a pre-existing `neospec.toml` fix narrowing coverage to `lua/yoda/`

## Motivation
The quality badge was a static `shields.io` URL with no automated update mechanism and no known data source. A badge that cannot be trusted is worse than no badge — it misleads readers about the actual state of the project.

## Changes
- `README.md`: removed the static quality badge line
- `neospec.toml`: narrowed `coverage_include` from `lua/` to `lua/yoda/` to restrict instrumentation to source files only

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes (92 tests, 100% coverage)