### PR TITLE
refactor(keymaps): align terminal-mode window navigation with normal mode

### DIFF
--- a/lua/yoda/keymaps/terminal.lua
+++ b/lua/yoda/keymaps/terminal.lua
@@ -31,11 +31,11 @@ map("n", "<leader>vt", function()
   })
 end, { desc = "Terminal: Floating shell - Open zsh terminal in floating window" })
 
--- Navigate out of terminal mode with Ctrl+w + direction
-map("t", "<C-w>h", "<C-\\><C-n><C-w>h", { desc = "Window: Move left from terminal" })
-map("t", "<C-w>j", "<C-\\><C-n><C-w>j", { desc = "Window: Move down from terminal" })
-map("t", "<C-w>k", "<C-\\><C-n><C-w>k", { desc = "Window: Move up from terminal" })
-map("t", "<C-w>l", "<C-\\><C-n><C-w>l", { desc = "Window: Move right from terminal" })
+-- Navigate out of terminal mode with Ctrl + direction
+map("t", "<C-h>", "<C-\\><C-n><C-w>h", { desc = "Window: Move left from terminal" })
+map("t", "<C-j>", "<C-\\><C-n><C-w>j", { desc = "Window: Move down from terminal" })
+map("t", "<C-k>", "<C-\\><C-n><C-w>k", { desc = "Window: Move up from terminal" })
+map("t", "<C-l>", "<C-\\><C-n><C-w>l", { desc = "Window: Move right from terminal" })
 
 map("n", "<leader>vr", function()
   local function get_python()

--- a/tests/unit/keymaps/terminal_spec.lua
+++ b/tests/unit/keymaps/terminal_spec.lua
@@ -1,0 +1,32 @@
+-- tests/unit/keymaps/terminal_spec.lua
+-- Verify terminal keymaps are defined in the source file.
+
+describe("keymaps.terminal", function()
+  local filepath = vim.fn.getcwd() .. "/lua/yoda/keymaps/terminal.lua"
+
+  local function read_source()
+    local lines = vim.fn.readfile(filepath)
+    assert.is_not_nil(lines, "terminal.lua should exist")
+    return table.concat(lines, "\n")
+  end
+
+  it("maps <C-h> in terminal mode to move to the left window", function()
+    local content = read_source()
+    assert.is_truthy(content:find('map%("t",%s*"<C%-h>"'), "Expected <C-h> terminal mode mapping for left window navigation")
+  end)
+
+  it("maps <C-j> in terminal mode to move to the window below", function()
+    local content = read_source()
+    assert.is_truthy(content:find('map%("t",%s*"<C%-j>"'), "Expected <C-j> terminal mode mapping for down window navigation")
+  end)
+
+  it("maps <C-k> in terminal mode to move to the window above", function()
+    local content = read_source()
+    assert.is_truthy(content:find('map%("t",%s*"<C%-k>"'), "Expected <C-k> terminal mode mapping for up window navigation")
+  end)
+
+  it("maps <C-l> in terminal mode to move to the right window", function()
+    local content = read_source()
+    assert.is_truthy(content:find('map%("t",%s*"<C%-l>"'), "Expected <C-l> terminal mode mapping for right window navigation")
+  end)
+end)

--- a/tests/unit/keymaps/window_spec.lua
+++ b/tests/unit/keymaps/window_spec.lua
@@ -1,0 +1,32 @@
+-- tests/unit/keymaps/window_spec.lua
+-- Verify window navigation keymaps are defined in the source file.
+
+describe("keymaps.window", function()
+  local filepath = vim.fn.getcwd() .. "/lua/yoda/keymaps/window.lua"
+
+  local function read_source()
+    local lines = vim.fn.readfile(filepath)
+    assert.is_not_nil(lines, "window.lua should exist")
+    return table.concat(lines, "\n")
+  end
+
+  it("maps <C-h> to move to the left window", function()
+    local content = read_source()
+    assert.is_truthy(content:find("<C%-h>"), "Expected <C-h> mapping for left window navigation")
+  end)
+
+  it("maps <C-j> to move to the window below", function()
+    local content = read_source()
+    assert.is_truthy(content:find("<C%-j>"), "Expected <C-j> mapping for down window navigation")
+  end)
+
+  it("maps <C-k> to move to the window above", function()
+    local content = read_source()
+    assert.is_truthy(content:find("<C%-k>"), "Expected <C-k> mapping for up window navigation")
+  end)
+
+  it("maps <C-l> to move to the right window", function()
+    local content = read_source()
+    assert.is_truthy(content:find("<C%-l>"), "Expected <C-l> mapping for right window navigation")
+  end)
+end)


### PR DESCRIPTION
## Summary
- Terminal-mode window navigation now uses `<C-h/j/k/l>` to match normal mode.
- Adds keymap specs covering both terminal and window modules.

## Motivation
Normal mode navigates between windows with `<C-h/j/k/l>`, but terminal mode required `<C-w>{h,j,k,l}`. The two-keystroke prefix in terminal mode broke muscle memory and forced a context switch every time you hopped out of a terminal split. Aligning the bindings makes window navigation reflexive everywhere.

## Changes
- `lua/yoda/keymaps/terminal.lua` — replace `<C-w>{h,j,k,l}` with `<C-h/j/k/l>` for terminal-mode window movement (each still escapes terminal mode via `<C-\><C-n>` before the move).
- `tests/unit/keymaps/terminal_spec.lua` — assert the four terminal-mode bindings are present.
- `tests/unit/keymaps/window_spec.lua` — guard the four normal-mode bindings against future regression.

## Test Plan
- [ ] `make lint` is clean.
- [ ] `make test` passes (240 tests, including the eight new keymap specs).
- [ ] In a terminal split, `<C-h>` / `<C-j>` / `<C-k>` / `<C-l>` move focus out of the terminal in the expected direction.
- [ ] In a normal-mode split, the same bindings still move between windows as before.