### PR TITLE
feat(lsp): add assembly language support via asm-lsp

### DIFF
--- a/lua/plugins/mason.lua
+++ b/lua/plugins/mason.lua
@@ -50,6 +50,7 @@ return {
           "basedpyright",
           "yamlls",
           "autotools_ls", -- Makefile/Autotools LSP server
+          "asm_lsp", -- Assembly LSP server (GAS/NASM, x86/ARM/RISC-V)
           "marksman", -- Markdown LSP server
           -- NOTE: jdtls (Java/Groovy) is intentionally absent — it requires
           -- manual installation (e.g. `brew install jdtls`) because Mason

--- a/lua/yoda/lsp.lua
+++ b/lua/yoda/lsp.lua
@@ -285,6 +285,16 @@ function M.setup()
     root_markers = { "Makefile", "Makefile.am", "configure.ac", "GNUmakefile", ".git" },
   })
 
+  -- Assembly setup (asm-lsp: GAS/NASM/GO asm, x86/x86-64, ARM, RISC-V, etc.)
+  -- Hover docs are sourced from official Intel/ARM references; diagnostics are
+  -- produced by shelling out to gcc/clang, so they degrade gracefully when no
+  -- compiler is on PATH. .asm-lsp.toml lets a project pin its assembler/arch.
+  safe_setup("asm_lsp", {
+    cmd = { "asm-lsp" },
+    filetypes = { "asm", "vmasm" },
+    root_markers = { ".asm-lsp.toml", ".git" },
+  })
+
   -- Markdown setup
   safe_setup("marksman", {
     cmd = { "marksman", "server" },


### PR DESCRIPTION
## What

Adds assembly language support to the distribution via [`asm-lsp`](https://github.com/bergercookie/asm-lsp).

- **`lua/yoda/lsp.lua`** — `safe_setup("asm_lsp", …)` block (filetypes `asm`/`vmasm`, root markers `.asm-lsp.toml`/`.git`). `yoda.lsp.setup()` remains the single source of truth for all `vim.lsp.config` calls.
- **`lua/plugins/mason.lua`** — `"asm_lsp"` added to `ensure_installed`; `mason-lspconfig`'s `automatic_enable` handles `vim.lsp.enable`.

## Why

`asm-lsp` is the most mature assembly LSP — a single static Rust binary, covering GAS/NASM/GO asm across x86/x86-64, ARM, and RISC-V. Hover docs come from official Intel/ARM references; diagnostics shell out to `gcc`/`clang` and degrade gracefully when no compiler is on `PATH`.

## Stability notes (per `.claude/rules/stability-first.md`)

- **Risk:** low — LSP is opt-in by filetype; worst case is no completions on `.asm` files.
- **Maturity:** 3+ years of stable releases, packaged in Mason + nvim-lspconfig.
- **Rollback:** revert this commit; no `lazy-lock.json` churn.

## Validation

- `stylua --check` passes on both changed files.
- `make test` skipped — declarative config addition with no new Lua logic to exercise.