### PR TITLE
feat(lsp): attach asm-lsp to nasm filetype too

### DIFF
--- a/lua/yoda/lsp.lua
+++ b/lua/yoda/lsp.lua
@@ -289,9 +289,13 @@ function M.setup()
   -- Hover docs are sourced from official Intel/ARM references; diagnostics are
   -- produced by shelling out to gcc/clang, so they degrade gracefully when no
   -- compiler is on PATH. .asm-lsp.toml lets a project pin its assembler/arch.
+  -- "nasm" is added beyond lspconfig's default { asm, vmasm }: Neovim assigns the
+  -- `nasm` filetype to *.nasm files, and asm-lsp supports the NASM dialect, so
+  -- without this those buffers would never get a server. *.s/*.S/*.asm all map to
+  -- the `asm` filetype regardless of dialect, so they're already covered.
   safe_setup("asm_lsp", {
     cmd = { "asm-lsp" },
-    filetypes = { "asm", "vmasm" },
+    filetypes = { "asm", "vmasm", "nasm" },
     root_markers = { ".asm-lsp.toml", ".git" },
   })
 


### PR DESCRIPTION
## What

Adds `"nasm"` to the `asm_lsp` `filetypes` list (now `{ "asm", "vmasm", "nasm" }`).

## Why

Follow-up to #47. Neovim assigns the `nasm` filetype to `*.nasm` files, and `asm-lsp` supports the NASM dialect — but lspconfig's default filetype list omits `nasm`, so those buffers never got a server. Verified against Neovim's built-in detection:

| File | Detected filetype | Covered by #47? |
|------|-------------------|-----------------|
| `*.s`, `*.S`, `*.asm` (any dialect) | `asm` | ✅ already |
| `*.nasm` | `nasm` | ❌ → fixed here |

`*.s`/`*.S`/`*.asm` all map to the `asm` filetype regardless of dialect, so they were already covered; this closes the dedicated-`.nasm`-extension gap.

## Validation

- `stylua --check` passes.
- Config-only change; no new Lua logic.