### PR TITLE
fix(keymaps): rename <leader>Gg to <leader>gg

### DIFF
--- a/doc/yoda-getting-started.txt
+++ b/doc/yoda-getting-started.txt
@@ -82,7 +82,7 @@ DEVELOPMENT WORKFLOW                            *yoda-getting-started-workflow*
   • Code Actions: <leader>la
 
 4. Git Integration~
-  • Git Status: <leader>Gg (opens Neogit)
+  • Git Status: <leader>gg (opens Neogit)
   • Stage Changes: <leader>hs (stage hunk)
   • View Diff: <leader>hd
 

--- a/doc/yoda-keymaps.txt
+++ b/doc/yoda-keymaps.txt
@@ -137,7 +137,7 @@ pytest-atlas ~
 ==============================================================================
 GIT INTEGRATION                                           *yoda-keymaps-git*
 
-    <leader>Gg      (n)    Open Neogit (interactive git interface)
+    <leader>gg      (n)    Open Neogit (interactive git interface)
     <leader>gB      (n)    Git blame full file (Fugitive)
 
 Gitsigns hunk operations (blame, stage, reset, diff, navigate) are registered

--- a/lua/yoda/keymaps/git.lua
+++ b/lua/yoda/keymaps/git.lua
@@ -7,6 +7,6 @@ end
 -- are registered as buffer-local keymaps inside the gitsigns on_attach callback
 -- in lua/plugins/git.lua. Global duplicates have been removed.
 
-map("n", "<leader>Gg", function()
+map("n", "<leader>gg", function()
   require("neogit").open()
 end, { desc = "Git: Open Neogit" })


### PR DESCRIPTION
## Summary

- Rename the Neogit keymap from `<leader>Gg` (mixed case) to `<leader>gg`
- Update vimdoc references in `doc/yoda-keymaps.txt` and `doc/yoda-getting-started.txt`

## Why

The mixed case felt wrong: which-key registers `<leader>g` as the "Git" group (`lua/plugins/which-key.lua:17`), and the comment in `lua/yoda/keymaps/go.lua:61` already refers to this binding as `<leader>gg` — so the implementation was the outlier.

**Note for users:** this is a user-visible keymap change. If you've trained muscle memory on `<leader>Gg`, you'll need to relearn `<leader>gg`.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (240 tests, 100% coverage)
- [ ] Manual: press `<leader>gg` in Neovim and confirm Neogit opens
- [ ] Manual: `:help yoda-keymaps-git` shows the corrected binding