### PR TITLE
build(make): include root init.lua in lint and format targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ test-verbose:
 
 # Lint code with stylua
 lint:
-	@find lua tests -name "*.lua" -type f | xargs stylua --check
+	@find init.lua lua tests -name "*.lua" -type f | xargs stylua --check
 
 # Format code with stylua
 format:
-	@find lua tests -name "*.lua" -type f | xargs stylua
+	@find init.lua lua tests -name "*.lua" -type f | xargs stylua
 
 # Performance benchmarking
 benchmark:


### PR DESCRIPTION
## Summary

- `make lint` and `make format` now glob `init.lua lua tests` instead of just `lua tests`
- Root `init.lua` is now covered by the formatter automatically — no more silent escape

## Why

The lint/format targets globbed `lua tests` only. Root `init.lua` had eight lines over 80 columns that stylua would have re-wrapped, but `make format` skipped the file entirely because it wasn't in the find path. This change closes the gap so future formatter changes stay in sync across all Lua sources.

## Test plan

- [x] `make lint` passes
- [x] `make format` no-op on the working tree (everything already conformant)
- [x] `find init.lua lua tests -name "*.lua" -type f | wc -l` matches the expected file count