### PR TITLE
feat(startup): boot into AI workspace with `nvim claude`/`nvim c`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ benchmarks/temp/
 # Test coverage output
 coverage/
 
+
+# Task tracking (local only)
+TODO.md

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Once installed, all language servers provide:
 | `<leader>sb` | Search open buffers (mini.pick) |
 
 ### 🤖 AI Features (Claude Code)
+
+> **Startup shortcut**: launch with `nvim claude` (or `nvim c`) to boot straight
+> into an AI workspace — Snacks explorer on the left, Claude Code expanded to
+> fill the space to its right, no dashboard. A real file/dir named `claude`/`c`
+> still opens normally. See `:help yoda-ai-startup`.
+
 | Keymap | Description |
 |--------|-------------|
 | `<leader>ai` | Toggle Claude Code |

--- a/doc/tags
+++ b/doc/tags
@@ -3,6 +3,7 @@ yoda-ai-contents	yoda-ai.txt	/*yoda-ai-contents*
 yoda-ai-keymaps	yoda-ai.txt	/*yoda-ai-keymaps*
 yoda-ai-prereqs	yoda-ai.txt	/*yoda-ai-prereqs*
 yoda-ai-setup	yoda-ai.txt	/*yoda-ai-setup*
+yoda-ai-startup	yoda-ai.txt	/*yoda-ai-startup*
 yoda-ai-trouble	yoda-ai.txt	/*yoda-ai-trouble*
 yoda-ai-verify	yoda-ai.txt	/*yoda-ai-verify*
 yoda-ai.txt	yoda-ai.txt	/*yoda-ai.txt*
@@ -123,6 +124,7 @@ yoda-keymaps-git	yoda-keymaps.txt	/*yoda-keymaps-git*
 yoda-keymaps-lsp	yoda-keymaps.txt	/*yoda-keymaps-lsp*
 yoda-keymaps-navigation	yoda-keymaps.txt	/*yoda-keymaps-navigation*
 yoda-keymaps-search	yoda-keymaps.txt	/*yoda-keymaps-search*
+yoda-keymaps-terminal	yoda-keymaps.txt	/*yoda-keymaps-terminal*
 yoda-keymaps-testing	yoda-keymaps.txt	/*yoda-keymaps-testing*
 yoda-keymaps-utilities	yoda-keymaps.txt	/*yoda-keymaps-utilities*
 yoda-keymaps-visual	yoda-keymaps.txt	/*yoda-keymaps-visual*
@@ -217,9 +219,8 @@ yoda-troubleshooting-contents	yoda-troubleshooting.txt	/*yoda-troubleshooting-co
 yoda-troubleshooting.txt	yoda-troubleshooting.txt	/*yoda-troubleshooting.txt*
 yoda-ui-compat	yoda-ui.txt	/*yoda-ui-compat*
 yoda-ui-contents	yoda-ui.txt	/*yoda-ui-contents*
-yoda-ui-notifier	yoda-ui.txt	/*yoda-ui-notifier*
+yoda-ui-noice	yoda-ui.txt	/*yoda-ui-noice*
 yoda-ui-trouble	yoda-ui.txt	/*yoda-ui-trouble*
-yoda-ui-ui2	yoda-ui.txt	/*yoda-ui-ui2*
 yoda-ui.txt	yoda-ui.txt	/*yoda-ui.txt*
 yoda-vim-essentials-big-picture	yoda-vim-essentials.txt	/*yoda-vim-essentials-big-picture*
 yoda-vim-essentials-commands	yoda-vim-essentials.txt	/*yoda-vim-essentials-commands*

--- a/doc/yoda-ai.txt
+++ b/doc/yoda-ai.txt
@@ -7,9 +7,10 @@ CONTENTS                                                   *yoda-ai-contents*
 
 1. Prerequisites ........................... |yoda-ai-prereqs|
 2. Claude Code Setup ....................... |yoda-ai-setup|
-3. Keymaps ................................. |yoda-ai-keymaps|
-4. Verification ............................ |yoda-ai-verify|
-5. Troubleshooting ......................... |yoda-ai-trouble|
+3. Startup Mode ............................ |yoda-ai-startup|
+4. Keymaps ................................. |yoda-ai-keymaps|
+5. Verification ............................ |yoda-ai-verify|
+6. Troubleshooting ......................... |yoda-ai-trouble|
 
 ==============================================================================
 PREREQUISITES                                               *yoda-ai-prereqs*
@@ -56,6 +57,29 @@ Yoda.nvim detects home/work environments via the YODA_ENV variable:
     # Home environment
     export YODA_ENV="home"
 <
+
+==============================================================================
+STARTUP MODE                                                *yoda-ai-startup*
+
+Launch Neovim directly into an AI workspace by passing "claude" (or the short
+alias "c") as the sole argument:
+>
+    nvim claude
+    nvim c
+<
+Instead of the dashboard, Yoda opens the Snacks explorer as a left sidebar and
+expands Claude Code to fill all horizontal space to its right, with the cursor
+in the Claude terminal so you can prompt immediately.
+
+This is the startup counterpart to <leader>ai (see |yoda-ai-keymaps|), which
+performs the same expand from within a running session.
+
+Notes:~
+  • Only a bare "claude"/"c" argument triggers the mode. If a file or
+    directory of that name exists in the current directory, Neovim edits it
+    normally instead.
+  • Any other launch is unaffected: `nvim`, `nvim <file>`, and multi-argument
+    invocations all behave exactly as before.
 
 ==============================================================================
 KEYMAPS                                                    *yoda-ai-keymaps*

--- a/init.lua
+++ b/init.lua
@@ -26,6 +26,20 @@ require("lazy-bootstrap")
 require("options")
 require("lazy-plugins")
 
+-- Register the `nvim claude` / `nvim c` startup mode before the scheduled
+-- block below: its VimEnter autocmd must be in place before VimEnter fires,
+-- which happens before the first vim.schedule callback runs. Snacks is already
+-- loaded (lazy = false) and the :ClaudeCode cmd trigger is registered by now.
+local ok_sm, startup_mode = pcall(require, "yoda.startup_mode")
+if ok_sm then
+  startup_mode.setup()
+else
+  vim.notify(
+    "[yoda] Failed to load yoda.startup_mode: " .. tostring(startup_mode),
+    vim.log.levels.WARN
+  )
+end
+
 -- ============================================================================
 -- Yoda Modules + Environment Setup
 -- ============================================================================

--- a/lua/yoda/startup_mode.lua
+++ b/lua/yoda/startup_mode.lua
@@ -1,0 +1,118 @@
+-- lua/yoda/startup_mode.lua
+--
+-- Optional command-line startup modes for Yoda. Currently one mode: `claude`.
+--
+-- Running `nvim claude` (or the short alias `nvim c`) boots straight into an AI
+-- workspace instead of the dashboard: the Snacks explorer opens as a left
+-- sidebar and Claude Code is expanded to fill all horizontal space to its
+-- right. This is the *startup* counterpart to the in-session `<leader>ai`
+-- dashboard-expand behavior in lua/plugins/claudecode.lua, and it reuses the
+-- same yoda-window.nvim reclaim_width helper so the two stay visually
+-- consistent.
+--
+-- Passing any argument already suppresses the Snacks dashboard (it only
+-- auto-shows with zero file args), so the only cleanup needed is wiping the
+-- phantom `claude`/`c` buffer that Neovim opens for the positional argument.
+
+local M = {}
+
+-- Bare arguments that select claude mode. A guard in mode_from_argv ensures a
+-- real file/directory of the same name still opens normally, so these short
+-- tokens never hijack an actual `claude` or `c` path in the cwd.
+local TRIGGERS = {
+  claude = true,
+  c = true,
+}
+
+--- Decide which startup mode (if any) a set of command-line arguments selects.
+--- Pure aside from the on-disk existence check, which keeps it testable with an
+--- injected argv table.
+--- @param argv string[] Command-line file arguments (as from vim.fn.argv())
+--- @return string|nil mode "claude" when claude mode is selected, else nil
+function M.mode_from_argv(argv)
+  if type(argv) ~= "table" or #argv ~= 1 then
+    return nil
+  end
+
+  local arg = argv[1]
+  if not TRIGGERS[arg] then
+    return nil
+  end
+
+  -- Collision guard: if the user actually has a file or directory named
+  -- "claude"/"c" in the cwd, treat the argument as a normal path to edit.
+  if vim.fn.filereadable(arg) == 1 or vim.fn.isdirectory(arg) == 1 then
+    return nil
+  end
+
+  return "claude"
+end
+
+--- Build the claude-mode layout: Snacks explorer sidebar on the left, Claude
+--- Code expanded to fill everything to its right, dashboard/phantom buffer
+--- removed, focus in the Claude terminal.
+---
+--- Every external dependency is guarded so a missing plugin degrades to a plain
+--- `:ClaudeCode` rather than erroring during startup.
+function M.start_claude_layout()
+  -- The window/buffer Neovim opened for the `claude`/`c` argument. We hand its
+  -- space to Claude and then wipe the buffer.
+  local phantom_win = vim.api.nvim_get_current_win()
+  local phantom_buf = vim.api.nvim_get_current_buf()
+
+  local snacks_ok, snacks = pcall(require, "snacks")
+  if snacks_ok then
+    pcall(function()
+      snacks.explorer.open()
+    end)
+  end
+
+  vim.cmd("ClaudeCode")
+
+  -- Claude's terminal spawns asynchronously; defer until its window exists so
+  -- reclaim_width can measure and resize it. Mirrors the pattern in
+  -- lua/plugins/claudecode.lua.
+  vim.schedule(function()
+    local term_ok, terminal = pcall(require, "claudecode.terminal")
+    local term_buf = term_ok and terminal.get_active_terminal_bufnr()
+    local claude_win = term_buf and vim.fn.bufwinid(term_buf) or -1
+    if claude_win == -1 then
+      return
+    end
+
+    -- Grow Claude into the space right of the explorer, closing the phantom
+    -- window in the process (reclaim_width stops short of the explorer
+    -- sidebar). Degrades gracefully if yoda-window.nvim is unavailable.
+    local win_ok, win_utils = pcall(require, "yoda-window.utils")
+    if win_ok and vim.api.nvim_win_is_valid(phantom_win) then
+      pcall(win_utils.reclaim_width, phantom_win, claude_win)
+    end
+
+    if vim.api.nvim_buf_is_valid(phantom_buf) then
+      pcall(vim.api.nvim_buf_delete, phantom_buf, { force = true })
+    end
+
+    if vim.api.nvim_win_is_valid(claude_win) then
+      pcall(vim.api.nvim_set_current_win, claude_win)
+    end
+  end)
+end
+
+--- Register the VimEnter hook that activates a startup mode when the
+--- command-line arguments select one. Idempotent: the augroup is cleared on
+--- each call and the autocmd fires once.
+function M.setup()
+  local group = vim.api.nvim_create_augroup("YodaStartupMode", { clear = true })
+  vim.api.nvim_create_autocmd("VimEnter", {
+    group = group,
+    once = true,
+    desc = "Activate Yoda claude startup mode when `nvim claude`/`nvim c` is run",
+    callback = function()
+      if M.mode_from_argv(vim.fn.argv()) == "claude" then
+        M.start_claude_layout()
+      end
+    end,
+  })
+end
+
+return M

--- a/tests/unit/startup_mode_spec.lua
+++ b/tests/unit/startup_mode_spec.lua
@@ -1,0 +1,345 @@
+-- tests/unit/startup_mode_spec.lua
+-- Validates the `nvim claude` startup mode: argv detection (mode_from_argv)
+-- and the layout builder (start_claude_layout) that opens the Snacks explorer,
+-- launches Claude Code, and grows Claude into the space right of the explorer
+-- via yoda-window.nvim's reclaim_width.
+
+describe("yoda.startup_mode", function()
+  local startup_mode
+
+  before_each(function()
+    package.loaded["yoda.startup_mode"] = nil
+    pcall(vim.api.nvim_del_augroup_by_name, "YodaStartupMode")
+    startup_mode = require("yoda.startup_mode")
+  end)
+
+  after_each(function()
+    package.loaded["yoda.startup_mode"] = nil
+    pcall(vim.api.nvim_del_augroup_by_name, "YodaStartupMode")
+  end)
+
+  describe("mode_from_argv", function()
+    local original_filereadable = vim.fn.filereadable
+    local original_isdirectory = vim.fn.isdirectory
+
+    before_each(function()
+      -- Default: nothing named "claude" exists on disk.
+      vim.fn.filereadable = function()
+        return 0
+      end
+      vim.fn.isdirectory = function()
+        return 0
+      end
+    end)
+
+    after_each(function()
+      vim.fn.filereadable = original_filereadable
+      vim.fn.isdirectory = original_isdirectory
+    end)
+
+    it("returns 'claude' for a lone 'claude' argument", function()
+      -- Arrange
+      local argv = { "claude" }
+
+      -- Act
+      local mode = startup_mode.mode_from_argv(argv)
+
+      -- Assert
+      assert.equals("claude", mode)
+    end)
+
+    it("returns 'claude' for the short 'c' alias", function()
+      -- Arrange
+      local argv = { "c" }
+
+      -- Act
+      local mode = startup_mode.mode_from_argv(argv)
+
+      -- Assert
+      assert.equals("claude", mode)
+    end)
+
+    it("returns nil when a readable file named 'c' exists", function()
+      -- Arrange
+      vim.fn.filereadable = function(name)
+        return name == "c" and 1 or 0
+      end
+
+      -- Act / Assert
+      assert.is_nil(startup_mode.mode_from_argv({ "c" }))
+    end)
+
+    it("returns nil when there are no arguments", function()
+      -- Arrange
+      local argv = {}
+
+      -- Act / Assert
+      assert.is_nil(startup_mode.mode_from_argv(argv))
+    end)
+
+    it("returns nil when 'claude' is not the only argument", function()
+      -- Arrange
+      local argv = { "claude", "extra.lua" }
+
+      -- Act / Assert
+      assert.is_nil(startup_mode.mode_from_argv(argv))
+    end)
+
+    it("returns nil for an unrelated argument", function()
+      -- Arrange
+      local argv = { "init.lua" }
+
+      -- Act / Assert
+      assert.is_nil(startup_mode.mode_from_argv(argv))
+    end)
+
+    it("returns nil when a readable file named 'claude' exists", function()
+      -- Arrange
+      vim.fn.filereadable = function(name)
+        return name == "claude" and 1 or 0
+      end
+
+      -- Act / Assert
+      assert.is_nil(startup_mode.mode_from_argv({ "claude" }))
+    end)
+
+    it("returns nil when a directory named 'claude' exists", function()
+      -- Arrange
+      vim.fn.isdirectory = function(name)
+        return name == "claude" and 1 or 0
+      end
+
+      -- Act / Assert
+      assert.is_nil(startup_mode.mode_from_argv({ "claude" }))
+    end)
+  end)
+
+  describe("start_claude_layout", function()
+    local originals = {}
+
+    before_each(function()
+      package.loaded["snacks"] = nil
+      package.loaded["yoda-window.utils"] = nil
+      package.loaded["claudecode.terminal"] = nil
+
+      originals.cmd = vim.cmd
+      originals.schedule = vim.schedule
+      originals.bufwinid = vim.fn.bufwinid
+      originals.get_current_win = vim.api.nvim_get_current_win
+      originals.get_current_buf = vim.api.nvim_get_current_buf
+      originals.win_is_valid = vim.api.nvim_win_is_valid
+      originals.buf_is_valid = vim.api.nvim_buf_is_valid
+      originals.buf_delete = vim.api.nvim_buf_delete
+      originals.set_current_win = vim.api.nvim_set_current_win
+
+      -- Run scheduled work synchronously so assertions don't need an event tick.
+      vim.schedule = function(fn)
+        fn()
+      end
+      -- The phantom startup window/buffer that `nvim claude` opens.
+      vim.api.nvim_get_current_win = function()
+        return 100
+      end
+      vim.api.nvim_get_current_buf = function()
+        return 200
+      end
+      vim.api.nvim_win_is_valid = function()
+        return true
+      end
+      vim.api.nvim_buf_is_valid = function()
+        return true
+      end
+    end)
+
+    after_each(function()
+      vim.cmd = originals.cmd
+      vim.schedule = originals.schedule
+      vim.fn.bufwinid = originals.bufwinid
+      vim.api.nvim_get_current_win = originals.get_current_win
+      vim.api.nvim_get_current_buf = originals.get_current_buf
+      vim.api.nvim_win_is_valid = originals.win_is_valid
+      vim.api.nvim_buf_is_valid = originals.buf_is_valid
+      vim.api.nvim_buf_delete = originals.buf_delete
+      vim.api.nvim_set_current_win = originals.set_current_win
+      package.loaded["snacks"] = nil
+      package.loaded["yoda-window.utils"] = nil
+      package.loaded["claudecode.terminal"] = nil
+    end)
+
+    it(
+      "opens the explorer, runs ClaudeCode, and reclaims width for Claude",
+      function()
+        -- Arrange
+        local explorer_opened = false
+        package.loaded["snacks"] = {
+          explorer = {
+            open = function()
+              explorer_opened = true
+            end,
+          },
+        }
+        local cmds = {}
+        vim.cmd = function(c)
+          table.insert(cmds, c)
+        end
+        package.loaded["claudecode.terminal"] = {
+          get_active_terminal_bufnr = function()
+            return 42
+          end,
+        }
+        vim.fn.bufwinid = function(buf)
+          return buf == 42 and 7 or -1
+        end
+        local reclaimed, focused, deleted
+        package.loaded["yoda-window.utils"] = {
+          reclaim_width = function(close_win, target_win)
+            reclaimed = { close_win = close_win, target_win = target_win }
+          end,
+        }
+        vim.api.nvim_set_current_win = function(win)
+          focused = win
+        end
+        vim.api.nvim_buf_delete = function(buf)
+          deleted = buf
+        end
+
+        -- Act
+        startup_mode.start_claude_layout()
+
+        -- Assert
+        assert.is_true(explorer_opened)
+        assert.is_true(vim.tbl_contains(cmds, "ClaudeCode"))
+        assert.same({ close_win = 100, target_win = 7 }, reclaimed)
+        assert.equals(200, deleted)
+        assert.equals(7, focused)
+      end
+    )
+
+    it("degrades to a plain ClaudeCode when yoda-window is absent", function()
+      -- Arrange
+      package.loaded["snacks"] = {
+        explorer = { open = function() end },
+      }
+      local cmds = {}
+      vim.cmd = function(c)
+        table.insert(cmds, c)
+      end
+      package.loaded["claudecode.terminal"] = {
+        get_active_terminal_bufnr = function()
+          return 42
+        end,
+      }
+      vim.fn.bufwinid = function()
+        return 7
+      end
+      -- yoda-window.utils intentionally left unstubbed (require fails).
+
+      -- Act — must not raise even without the resize helper.
+      local ok = pcall(startup_mode.start_claude_layout)
+
+      -- Assert
+      assert.is_true(ok)
+      assert.is_true(vim.tbl_contains(cmds, "ClaudeCode"))
+    end)
+
+    it("does not resize when Claude's window can't be found", function()
+      -- Arrange
+      package.loaded["snacks"] = {
+        explorer = { open = function() end },
+      }
+      vim.cmd = function() end
+      package.loaded["claudecode.terminal"] = {
+        get_active_terminal_bufnr = function()
+          return nil
+        end,
+      }
+      package.loaded["yoda-window.utils"] = {
+        reclaim_width = function()
+          error("reclaim_width should not be called without a Claude window")
+        end,
+      }
+
+      -- Act
+      local ok = pcall(startup_mode.start_claude_layout)
+
+      -- Assert
+      assert.is_true(ok)
+    end)
+  end)
+
+  describe("setup", function()
+    it(
+      "registers a single VimEnter autocmd in the YodaStartupMode group",
+      function()
+        -- Arrange / Act
+        startup_mode.setup()
+
+        -- Assert
+        local autocmds = vim.api.nvim_get_autocmds({
+          group = "YodaStartupMode",
+          event = "VimEnter",
+        })
+        assert.equals(1, #autocmds)
+      end
+    )
+
+    it("does not build the layout when argv is not claude mode", function()
+      -- Arrange
+      local original_argv = vim.fn.argv
+      vim.fn.argv = function()
+        return {}
+      end
+      local built = false
+      -- The autocmd dispatches through the module table so it is overridable.
+      startup_mode.start_claude_layout = function()
+        built = true
+      end
+      startup_mode.setup()
+      local autocmds = vim.api.nvim_get_autocmds({
+        group = "YodaStartupMode",
+        event = "VimEnter",
+      })
+
+      -- Act
+      autocmds[1].callback()
+
+      -- Assert
+      assert.is_false(built)
+      vim.fn.argv = original_argv
+    end)
+
+    it("builds the layout when argv selects claude mode", function()
+      -- Arrange
+      local original_argv = vim.fn.argv
+      local original_filereadable = vim.fn.filereadable
+      local original_isdirectory = vim.fn.isdirectory
+      vim.fn.argv = function()
+        return { "claude" }
+      end
+      vim.fn.filereadable = function()
+        return 0
+      end
+      vim.fn.isdirectory = function()
+        return 0
+      end
+      local built = false
+      startup_mode.start_claude_layout = function()
+        built = true
+      end
+      startup_mode.setup()
+      local autocmds = vim.api.nvim_get_autocmds({
+        group = "YodaStartupMode",
+        event = "VimEnter",
+      })
+
+      -- Act
+      autocmds[1].callback()
+
+      -- Assert
+      assert.is_true(built)
+      vim.fn.argv = original_argv
+      vim.fn.filereadable = original_filereadable
+      vim.fn.isdirectory = original_isdirectory
+    end)
+  end)
+end)


### PR DESCRIPTION
## What

Adds an optional command-line startup mode. Launching with `claude` (or the short alias `c`) as the sole argument boots Neovim straight into an AI workspace instead of the dashboard:

- **Snacks explorer** opens as a left sidebar
- **Claude Code** is expanded to fill all horizontal space to its right
- No dashboard; cursor lands in the Claude terminal so you can prompt immediately

```bash
nvim claude   # or the short alias:
nvim c
```

This is the *startup* counterpart to the in-session `<leader>ai` dashboard-expand behavior, and it reuses the same `yoda-window.nvim` `reclaim_width` helper so the two stay visually consistent.

## How

- New module `lua/yoda/startup_mode.lua`:
  - `mode_from_argv(argv)` — pure detection with a **collision guard**: a real file/dir named `claude`/`c` in the cwd opens normally instead of triggering the mode.
  - `start_claude_layout()` — opens the explorer, runs `:ClaudeCode`, and grows Claude via `reclaim_width`. Every external dependency is guarded, so a missing plugin degrades to a plain `:ClaudeCode` rather than erroring at startup.
  - `setup()` — registers a `VimEnter`-once autocmd.
- `init.lua` calls `setup()` **before** the scheduled module block, since `VimEnter` fires before the first `vim.schedule` callback runs.
- Docs: README note + `:help yoda-ai-startup`.

## Unaffected

`nvim`, `nvim <file>`, and multi-argument launches all behave exactly as before.

## Testing

- `make lint` clean; `make test` → **260 passed, 0 failed, 100% coverage**.
- Headless end-to-end against real `nvim` launches: `claude`/`c` fire the layout; `nvim`, `nvim init.lua`, and the collision case (real `claude` file) do **not**.
- ⚠️ The live window arrangement (exact split + focus) needs a real TTY + `claude` CLI to eyeball — `reclaim_width` args are unit-tested, but reviewers should run `nvim claude` locally to confirm the visual result.

## Notes

- `lazy-lock.json` is intentionally **not** touched — no plugin surface changes.