### PR TITLE
fix(startup): defer claude focus and startinsert past later focus handlers

### DIFF
--- a/lua/yoda/startup_mode.lua
+++ b/lua/yoda/startup_mode.lua
@@ -92,9 +92,28 @@ function M.start_claude_layout()
       pcall(vim.api.nvim_buf_delete, phantom_buf, { force = true })
     end
 
-    if vim.api.nvim_win_is_valid(claude_win) then
-      pcall(vim.api.nvim_set_current_win, claude_win)
-    end
+    -- Defer the final focus + terminal-insert to the next tick so it lands
+    -- *after* every other startup focus handler that runs later in the loop
+    -- (snacks picker `p:focus()`, ClaudeCode's own scheduled start_insert,
+    -- any dashboard eviction). A plain vim.schedule here fires too early --
+    -- claude gets focus, then one of those handlers steals it back and the
+    -- user boots into the sidebar/normal mode instead of typing to Claude.
+    -- Re-resolve the claude window at defer time because the buffer may
+    -- have been swapped during the intervening focus dance.
+    vim.defer_fn(function()
+      local ok, terminal_mod = pcall(require, "claudecode.terminal")
+      local buf = ok and terminal_mod.get_active_terminal_bufnr()
+      local win = buf and vim.fn.bufwinid(buf) or -1
+      if win == -1 or not vim.api.nvim_win_is_valid(win) then
+        return
+      end
+      -- pcall: window may close between the valid-check and the focus call
+      -- (async terminal spawn); silent failure is the intended degrade.
+      pcall(vim.api.nvim_set_current_win, win)
+      -- pcall: non-fatal if the buffer isn't yet a terminal in degraded
+      -- startup (missing plugin, spawn failure); the user just presses `i`.
+      pcall(vim.cmd, "startinsert")
+    end, 50)
   end)
 end
 

--- a/tests/unit/startup_mode_spec.lua
+++ b/tests/unit/startup_mode_spec.lua
@@ -124,6 +124,7 @@ describe("yoda.startup_mode", function()
 
       originals.cmd = vim.cmd
       originals.schedule = vim.schedule
+      originals.defer_fn = vim.defer_fn
       originals.bufwinid = vim.fn.bufwinid
       originals.get_current_win = vim.api.nvim_get_current_win
       originals.get_current_buf = vim.api.nvim_get_current_buf
@@ -134,6 +135,11 @@ describe("yoda.startup_mode", function()
 
       -- Run scheduled work synchronously so assertions don't need an event tick.
       vim.schedule = function(fn)
+        fn()
+      end
+      -- The defer_fn tick that runs focus + startinsert after every other
+      -- startup focus handler; drive it synchronously in tests.
+      vim.defer_fn = function(fn, _)
         fn()
       end
       -- The phantom startup window/buffer that `nvim claude` opens.
@@ -154,6 +160,7 @@ describe("yoda.startup_mode", function()
     after_each(function()
       vim.cmd = originals.cmd
       vim.schedule = originals.schedule
+      vim.defer_fn = originals.defer_fn
       vim.fn.bufwinid = originals.bufwinid
       vim.api.nvim_get_current_win = originals.get_current_win
       vim.api.nvim_get_current_buf = originals.get_current_buf
@@ -214,6 +221,86 @@ describe("yoda.startup_mode", function()
         assert.equals(7, focused)
       end
     )
+
+    it("drops the cursor into terminal-insert mode inside Claude", function()
+      -- Regression: without `startinsert`, focus lands in Claude's terminal
+      -- window in normal mode, so the user has to press `i` before they can
+      -- type to Claude. Focus + startinsert must also happen in a deferred
+      -- tick *after* the layout work (buf_delete, set_current_win) so that
+      -- later startup focus handlers (snacks picker, ClaudeCode's own
+      -- scheduled start_insert) don't steal focus back to the sidebar.
+
+      -- Arrange
+      package.loaded["snacks"] = {
+        explorer = { open = function() end },
+      }
+      local events = {}
+      vim.cmd = function(c)
+        table.insert(events, "cmd:" .. c)
+      end
+      package.loaded["claudecode.terminal"] = {
+        get_active_terminal_bufnr = function()
+          return 42
+        end,
+      }
+      vim.fn.bufwinid = function()
+        return 7
+      end
+      package.loaded["yoda-window.utils"] = {
+        reclaim_width = function()
+          table.insert(events, "reclaim_width")
+        end,
+      }
+      vim.api.nvim_set_current_win = function()
+        table.insert(events, "set_current_win")
+      end
+      vim.api.nvim_buf_delete = function()
+        table.insert(events, "buf_delete")
+      end
+      -- Capture defer_fn ordering so we can prove the focus+startinsert ran
+      -- in the deferred tick, not inline with the layout work.
+      local deferred_ran = false
+      vim.defer_fn = function(fn, _)
+        table.insert(events, "defer_start")
+        fn()
+        deferred_ran = true
+        table.insert(events, "defer_end")
+      end
+
+      -- Act
+      startup_mode.start_claude_layout()
+
+      -- Assert
+      assert.is_true(deferred_ran, "defer_fn tick must run")
+      local idx = {}
+      for i, ev in ipairs(events) do
+        idx[ev] = idx[ev] or i
+      end
+      assert.is_truthy(idx["cmd:ClaudeCode"], "ClaudeCode must be issued")
+      assert.is_truthy(
+        idx["cmd:startinsert"],
+        "expected startinsert to be issued"
+      )
+      assert.is_true(
+        idx["cmd:startinsert"] > idx["defer_start"],
+        "startinsert must run inside the deferred tick, not the inline schedule"
+      )
+      assert.is_true(
+        idx["cmd:startinsert"] > idx["buf_delete"],
+        "startinsert must run after the phantom buffer is cleaned up"
+      )
+      assert.is_true(
+        idx["set_current_win"] > idx["buf_delete"],
+        "focus swap must happen after the phantom buffer is cleaned up"
+      )
+      local insert_count = 0
+      for _, ev in ipairs(events) do
+        if ev == "cmd:startinsert" then
+          insert_count = insert_count + 1
+        end
+      end
+      assert.equals(1, insert_count, "startinsert must be called exactly once")
+    end)
 
     it("degrades to a plain ClaudeCode when yoda-window is absent", function()
       -- Arrange


### PR DESCRIPTION
## Summary

- Focus and `startinsert` for the `nvim claude` / `nvim c` startup layout ran inline with the layout work, so later startup focus handlers (snacks picker `p:focus()`, ClaudeCode's own scheduled `start_insert`, dashboard eviction) stole focus back and left the user in the sidebar or in normal mode inside the terminal.
- Move the final focus and `startinsert` into a `vim.defer_fn(_, 50)` tick that fires after every other startup handler. Re-resolve the claude window at defer time because the buffer may have been swapped during the intervening focus dance.
- Add a regression spec that captures the deferred ordering (focus + `startinsert` land inside the deferred tick, after `buf_delete`, exactly once).

## Test plan

- [x] `make lint` (stylua clean)
- [x] `make test` (261 passed, 0 failed, 100% coverage)
- [ ] Smoke test: `nvim claude` — cursor drops into terminal-insert mode inside Claude, no need to press `i`
- [ ] Smoke test: `nvim c` — same
- [ ] Smoke test: `nvim` (no argv) — normal startup unaffected