### PR TITLE
chore(deps): track rustaceanvim on master branch

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -40,7 +40,7 @@
   "package-info.nvim": { "branch": "master", "commit": "9725099fb118bab8360e560c1219bff60763b7e1" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
   "pytest-atlas.nvim": { "branch": "main", "commit": "6c1c6177a97764971762d6b5e28f44053168d39a" },
-  "rustaceanvim": { "branch": "main", "commit": "e9c5aaba16fead831379d5f44617547a90b913c7" },
+  "rustaceanvim": { "branch": "master", "commit": "e9c5aaba16fead831379d5f44617547a90b913c7" },
   "showkeys": { "branch": "main", "commit": "cb0a50296f11f1e585acffba8c253b9e8afc1f84" },
   "snacks.nvim": { "branch": "main", "commit": "882c996cf28183f4d63640de0b4c02ec886d01f2" },
   "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },


### PR DESCRIPTION
## Summary

- Upstream `mrcjkb/rustaceanvim` uses `master` as its default branch, not `main`.
- Align `lazy-lock.json`'s `branch` field so lazy.nvim doesn't spuriously flag the plugin as unpinned or drift onto the wrong ref when the lock is regenerated.
- Commit SHA is unchanged — no plugin version change, only the tracked branch name.

## Test plan

- [x] `make lint` (stylua clean)
- [x] `make test` (261 passed, 100% coverage)
- [ ] `:Lazy check` reports no pending update for rustaceanvim