### PR TITLE
fix(session): scope ShaDa per-project and sweep stale tmp files

### DIFF
--- a/lua/options.lua
+++ b/lua/options.lua
@@ -102,6 +102,19 @@ vim.opt.writebackup = false
 vim.opt.swapfile = false
 
 -- ShaDa (shared data) settings for better reliability
+--
+-- WHY per-project file: a single shared main.shada written by many concurrent
+-- nvim instances (common in this workflow) races on the same tmp.<letter>
+-- rename, orphaning temp files that eventually exhaust a-z and throw E138.
+-- Scoping the file to the cwd means only instances open in the *same*
+-- project can collide, which is far rarer.
+local shada_dir = vim.fn.stdpath("state") .. "/shada"
+vim.fn.mkdir(shada_dir, "p")
+local project_shada_file = shada_dir
+  .. "/proj"
+  .. vim.fn.getcwd():gsub("/", "%%")
+  .. ".shada"
+
 vim.opt.shada = {
   "!", -- Save global variables
   "'100", -- Save marks for last 100 files
@@ -110,6 +123,7 @@ vim.opt.shada = {
   "h", -- Disable hlsearch when loading
   "f1", -- Store file marks
   "r/tmp", -- Skip removable media
+  "n" .. project_shada_file,
 }
 
 -- ============================================================================

--- a/lua/yoda/session.lua
+++ b/lua/yoda/session.lua
@@ -11,9 +11,40 @@
 
 local M = {}
 
+-- A hard kill (SIGKILL, crash, force-quit) skips VimLeavePre entirely, so
+-- orphaned *.shada.tmp.* files can still accumulate despite the forced write
+-- above. Sweep them on startup instead, since that's the one point every
+-- session reliably passes through. Only remove tmp files older than 5
+-- minutes so an in-progress write from another concurrent instance is never
+-- touched.
+local STALE_AFTER_SECONDS = 300
+
+local function cleanup_stale_shada_tmp()
+  local shada_dir = vim.fn.stdpath("state") .. "/shada"
+  local now = os.time()
+  for _, path in ipairs(vim.fn.glob(shada_dir .. "/*.tmp.*", false, true)) do
+    local stat = vim.loop.fs_stat(path)
+    if stat and (now - stat.mtime.sec) > STALE_AFTER_SECONDS then
+      local ok, err = pcall(os.remove, path)
+      if not ok then
+        vim.notify(
+          "[yoda] failed to remove stale ShaDa temp file "
+            .. path
+            .. ": "
+            .. tostring(err),
+          vim.log.levels.WARN
+        )
+      end
+    end
+  end
+end
+
 function M.setup()
+  local group =
+    vim.api.nvim_create_augroup("YodaSessionCleanup", { clear = true })
+
   vim.api.nvim_create_autocmd("VimLeavePre", {
-    group = vim.api.nvim_create_augroup("YodaSessionCleanup", { clear = true }),
+    group = group,
     desc = "Force-write ShaDa on exit to prevent 'file already exists' warnings",
     callback = function()
       local ok, err = pcall(vim.cmd, "wshada!")
@@ -24,6 +55,12 @@ function M.setup()
         )
       end
     end,
+  })
+
+  vim.api.nvim_create_autocmd("VimEnter", {
+    group = group,
+    desc = "Remove stale orphaned ShaDa temp files left by hard-killed sessions",
+    callback = cleanup_stale_shada_tmp,
   })
 end
 


### PR DESCRIPTION
## Summary
- Scopes the ShaDa file to the current project (`getcwd()`) instead of one shared `main.shada`, since concurrent nvim instances writing to a single shared file race on the same `tmp.<letter>` rename slot and can exhaust it (`E138`)
- Adds a `VimEnter` autocommand that sweeps orphaned `*.shada.tmp.*` files older than 5 minutes, since a hard-killed session (SIGKILL/crash/force-quit) skips the existing `VimLeavePre` force-write and can leave temp files behind

## Test plan
- [ ] `make test`
- [ ] `make lint`
- [ ] Open multiple concurrent nvim instances in the same project and confirm no ShaDa warnings
- [ ] Manually create a stale `*.shada.tmp.*` file and confirm it's removed on next startup